### PR TITLE
fix: tests for windows

### DIFF
--- a/test/array.test.ts
+++ b/test/array.test.ts
@@ -3,7 +3,7 @@ import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { zodToTs } from '../src'
-import { printNodeTest } from './utils.js'
+import { printNodeTest } from './utils'
 
 const ItemsSchema = z.object({
   id: z.number(),

--- a/test/array.test.ts
+++ b/test/array.test.ts
@@ -2,7 +2,8 @@ import { dedent } from 'ts-dedent'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { printNode, zodToTs } from '../src'
+import { zodToTs } from '../src'
+import { printNodeTest } from './utils.js'
 
 const ItemsSchema = z.object({
   id: z.number(),
@@ -39,7 +40,7 @@ describe('z.array()', () => {
         value: string;
     }[]`)
 
-    const printedNode = printNode(node)
+    const printedNode = printNodeTest(node)
 
     expect(printedNode).toStrictEqual(expectedType)
   })

--- a/test/create-type-alias.test.ts
+++ b/test/create-type-alias.test.ts
@@ -2,7 +2,8 @@ import { dedent } from 'ts-dedent'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { createTypeAlias, printNode, zodToTs } from '../src'
+import { createTypeAlias, zodToTs } from '../src'
+import { printNodeTest } from './utils.js'
 
 const UserSchema = z.object({
   username: z.string(),
@@ -49,7 +50,7 @@ describe('type alias', () => {
           age: number;
       };`)
 
-    const printedNode = printNode(typeAlias)
+    const printedNode = printNodeTest(typeAlias)
 
     expect(printedNode).toStrictEqual(expectedType)
   })

--- a/test/create-type-alias.test.ts
+++ b/test/create-type-alias.test.ts
@@ -3,7 +3,7 @@ import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { createTypeAlias, zodToTs } from '../src'
-import { printNodeTest } from './utils.js'
+import { printNodeTest } from './utils'
 
 const UserSchema = z.object({
   username: z.string(),

--- a/test/instanceof.test.ts
+++ b/test/instanceof.test.ts
@@ -1,7 +1,8 @@
 import dedent from 'ts-dedent'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { printNode, withGetType, zodToTs } from '../src'
+import { withGetType, zodToTs } from '../src'
+import { printNodeTest } from './utils'
 
 const dateType = withGetType(z.instanceof(Date), (ts) => ts.factory.createIdentifier('Date'))
 
@@ -20,7 +21,7 @@ describe('z.instanceof()', () => {
         date: Date;
     }`)
 
-    const printedNode = printNode(node)
+    const printedNode = printNodeTest(node)
 
     expect(printedNode).toStrictEqual(expectedType)
   })

--- a/test/lazy.test.ts
+++ b/test/lazy.test.ts
@@ -3,7 +3,7 @@ import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { zodToTs } from '../src'
-import { printNodeTest } from './utils.js'
+import { printNodeTest } from './utils'
 
 type User = {
   username: string

--- a/test/lazy.test.ts
+++ b/test/lazy.test.ts
@@ -2,7 +2,8 @@ import { dedent } from 'ts-dedent'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { printNode, zodToTs } from '../src'
+import { zodToTs } from '../src'
+import { printNodeTest } from './utils.js'
 
 type User = {
   username: string
@@ -48,7 +49,7 @@ describe('z.lazy() referencing root type', () => {
         friends: User[];
     }`)
 
-    const printedNode = printNode(node)
+    const printedNode = printNodeTest(node)
 
     expect(printedNode).toStrictEqual(expectedType)
   })
@@ -62,7 +63,7 @@ describe('z.lazy() referencing root type', () => {
         friends: Identifier[];
     }`)
 
-    const printedNode = printNode(nodeWithoutSpecifiedIdentifier)
+    const printedNode = printNodeTest(nodeWithoutSpecifiedIdentifier)
 
     expect(printedNode).to.deep.equal(expectedType)
   })

--- a/test/modifiers.test.ts
+++ b/test/modifiers.test.ts
@@ -2,7 +2,8 @@ import { dedent } from 'ts-dedent'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { printNode, zodToTs } from '../src'
+import { zodToTs } from '../src'
+import { printNodeTest } from './utils.js'
 
 const OptionalStringSchema = z.string().optional()
 
@@ -20,7 +21,7 @@ describe('z.optional()', () => {
 
   it('outputs correct typescript', () => {
     const expectedType = 'string | undefined'
-    const printedNode = printNode(node)
+    const printedNode = printNodeTest(node)
     expect(printedNode).to.deep.equal(expectedType)
   })
 })
@@ -39,7 +40,7 @@ describe('z.optional()', () => {
 
   it('outputs correct typescript', () => {
     const expectedType = 'string | undefined'
-    const printedNode = printNode(node)
+    const printedNode = printNodeTest(node)
     expect(printedNode).toStrictEqual(expectedType)
   })
 })
@@ -75,7 +76,7 @@ describe('z.nullable()', () => {
         username: string | null;
     }`
 
-    const printedNode = printNode(node)
+    const printedNode = printNodeTest(node)
 
     expect(printedNode).toStrictEqual(expectedType)
   })

--- a/test/modifiers.test.ts
+++ b/test/modifiers.test.ts
@@ -3,7 +3,7 @@ import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { zodToTs } from '../src'
-import { printNodeTest } from './utils.js'
+import { printNodeTest } from './utils'
 
 const OptionalStringSchema = z.string().optional()
 

--- a/test/primitive.test.ts
+++ b/test/primitive.test.ts
@@ -2,7 +2,8 @@ import { dedent } from 'ts-dedent'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { printNode, zodToTs } from '../src'
+import { zodToTs } from '../src'
+import { printNodeTest } from './utils.js'
 
 const PrimitiveSchema = z.object({
   username: z.string(),
@@ -109,7 +110,7 @@ describe('PrimitiveSchema', () => {
         nev: never;
     }`)
 
-    const printedNode = printNode(node)
+    const printedNode = printNodeTest(node)
 
     expect(printedNode).toStrictEqual(expectedType)
   })

--- a/test/primitive.test.ts
+++ b/test/primitive.test.ts
@@ -3,7 +3,7 @@ import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { zodToTs } from '../src'
-import { printNodeTest } from './utils.js'
+import { printNodeTest } from './utils'
 
 const PrimitiveSchema = z.object({
   username: z.string(),

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,4 @@
 import ts, { NewLineKind } from 'typescript'
-import { printNode } from '../src/index.js'
+import { printNode } from '../src'
 
 export const printNodeTest = (node: ts.Node) => printNode(node, { newLine: NewLineKind.LineFeed })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,4 @@
+import ts, { NewLineKind } from 'typescript'
+import { printNode } from '../src/index.js'
+
+export const printNodeTest = (node: ts.Node) => printNode(node, { newLine: NewLineKind.LineFeed })


### PR DESCRIPTION
Tests were failing on windows due to line separators:
```
AssertionError: expected '{\r\n    username: string;\r\n    age…' to strictly equal '{\n    username: string;\n    age: nu…'
```