### PR TITLE
Better Optional Handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,12 +85,16 @@ const zodToTsNode = (
       const properties = Object.entries(zod._def.shape())
 
       const members: ts.TypeElement[] = properties.map(([key, value]) => {
-        const type = zodToTsNode(value as ZodTypeAny, ...otherArgs)
+        const nextZodNode = value as ZodTypeAny
+        const type = zodToTsNode(nextZodNode, ...otherArgs)
+
+        const { typeName: nextZodNodeTypeName } = nextZodNode._def
+        const isOptional = nextZodNodeTypeName === 'ZodOptional' || nextZodNode.isOptional()
 
         return f.createPropertySignature(
           undefined,
           f.createIdentifier(key),
-          undefined,
+          isOptional ? f.createToken(ts.SyntaxKind.QuestionToken) : undefined,
           type,
         )
       })

--- a/test/modifiers.test.ts
+++ b/test/modifiers.test.ts
@@ -7,6 +7,21 @@ import { printNodeTest } from './utils'
 
 const OptionalStringSchema = z.string().optional()
 
+const ObjectWithOptionals = z.object({
+  optional: OptionalStringSchema,
+  required: z.string(),
+  transform: z.number().optional().transform((arg) => arg),
+  or: z.number().optional().or(z.string()),
+  tuple: z.tuple([
+    z.string().optional(),
+    z.number(),
+    z.object({
+      optional: z.string().optional(),
+      required: z.string(),
+    }),
+  ]).optional(),
+})
+
 describe('z.optional()', () => {
   const { node } = zodToTs(OptionalStringSchema)
 
@@ -23,6 +38,27 @@ describe('z.optional()', () => {
     const expectedType = 'string | undefined'
     const printedNode = printNodeTest(node)
     expect(printedNode).to.deep.equal(expectedType)
+  })
+
+  it('for optionals should output ?: property as well as undefined union', () => {
+    const { node } = zodToTs(ObjectWithOptionals, undefined)
+
+    const expectedType = dedent `{
+      optional?: string | undefined;
+      required: string;
+      transform?: number | undefined;
+      or?: (number | undefined) | string;
+      tuple?: [
+          string | undefined,
+          number,
+          {
+              optional?: string | undefined;
+              required: string;
+          }
+      ] | undefined;
+    }`
+
+    expect(printNodeTest(node)).toStrictEqual(expectedType)
   })
 })
 

--- a/test/modifiers.test.ts
+++ b/test/modifiers.test.ts
@@ -29,7 +29,22 @@ describe('z.optional()', () => {
   it('for optionals should output ?: property as well as undefined union', () => {
     const { node } = zodToTs(ObjectWithOptionals)
 
-    expect(printNodeTest(node)).toMatchInlineSnapshot()
+    expect(printNodeTest(node)).toMatchInlineSnapshot(`
+      "{
+          optional?: string | undefined;
+          required: string;
+          transform?: number | undefined;
+          or?: (number | undefined) | string;
+          tuple?: [
+              string | undefined,
+              number,
+              {
+                  optional?: string | undefined;
+                  required: string;
+              }
+          ] | undefined;
+      }"
+    `)
   })
 })
 

--- a/test/primitive.test.ts
+++ b/test/primitive.test.ts
@@ -20,6 +20,19 @@ describe('PrimitiveSchema', () => {
   const { node } = zodToTs(PrimitiveSchema, 'User')
 
   it('outputs correct typescript', () => {
-    expect(printNodeTest(node)).toMatchInlineSnapshot()
+    expect(printNodeTest(node)).toMatchInlineSnapshot(`
+      "{
+          username: string;
+          age: number;
+          isAdmin: boolean;
+          createdAt: Date;
+          undef?: undefined;
+          nu: null;
+          vo?: void | undefined;
+          an?: any;
+          unknow?: unknown;
+          nev: never;
+      }"
+    `)
   })
 })

--- a/test/primitive.test.ts
+++ b/test/primitive.test.ts
@@ -53,7 +53,7 @@ describe('PrimitiveSchema', () => {
       ts.factory.createPropertySignature(
         undefined,
         ts.factory.createIdentifier('undef'),
-        undefined,
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
         ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
       ),
       ts.factory.createPropertySignature(
@@ -65,7 +65,7 @@ describe('PrimitiveSchema', () => {
       ts.factory.createPropertySignature(
         undefined,
         ts.factory.createIdentifier('vo'),
-        undefined,
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
         ts.factory.createUnionTypeNode([
           ts.factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword),
           ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
@@ -74,13 +74,13 @@ describe('PrimitiveSchema', () => {
       ts.factory.createPropertySignature(
         undefined,
         ts.factory.createIdentifier('an'),
-        undefined,
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
         ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
       ),
       ts.factory.createPropertySignature(
         undefined,
         ts.factory.createIdentifier('unknow'),
-        undefined,
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
         ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
       ),
       ts.factory.createPropertySignature(
@@ -102,11 +102,11 @@ describe('PrimitiveSchema', () => {
         age: number;
         isAdmin: boolean;
         createdAt: Date;
-        undef: undefined;
+        undef?: undefined;
         nu: null;
-        vo: void | undefined;
-        an: any;
-        unknow: unknown;
+        vo?: void | undefined;
+        an?: any;
+        unknow?: unknown;
         nev: never;
     }`)
 


### PR DESCRIPTION
Hey this is just a small PR looking to address the issue of optionals not being handled quite as they should be. I ran into the issue while using the library to generate my types

I noticed there is a [PR](https://github.com/sachinraja/zod-to-ts/pull/10) looking to do a similar thing currently but I do not think there is a need for a flag tbh. I agree with [robins comment](https://github.com/sachinraja/zod-to-ts/pull/10#issuecomment-1107540939) around the best idea being to aim to be as close as possible to the resulting types from `z.infer`

The main shortfall I would callout in this PR is that the `or` type 
`or: z.number().optional().or(z.string())` which transforms into `or?: (number | undefined) | string;`
Should actually look like `or?: number | undefined | string;` but think it is alright leaving that for now as a future improvement

Keen to get something like this in if possible since atm I am probably going to have to resort to using z.infer in a few places instead of my generated types!