### PR TITLE
addJsDocComment: enabling the trailing new line option

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,5 +54,5 @@ export const getIdentifierOrStringLiteral = (str: string) => {
 }
 
 export const addJsDocComment = (node: ts.Node, text: string) => {
-  ts.addSyntheticLeadingComment(node, ts.SyntaxKind.MultiLineCommentTrivia, `* ${text} `)
+  ts.addSyntheticLeadingComment(node, ts.SyntaxKind.MultiLineCommentTrivia, `* ${text} `, true)
 }

--- a/test/create-type-alias.test.ts
+++ b/test/create-type-alias.test.ts
@@ -32,7 +32,8 @@ describe('type alias', () => {
     )
 
     expect(printNodeTest(typeAlias)).toMatchInlineSnapshot(`
-      "/** A basic user */ type User = {
+      "/** A basic user */
+      type User = {
           username: string;
           age: number;
       };"

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -78,8 +78,10 @@ it('supports zod.describe()', () => {
 
   expect(printNodeTest(node)).toMatchInlineSnapshot(`
     "{
-        /** The name of the item */ name: string;
-        /** The price of the item */ price: number;
+        /** The name of the item */
+        name: string;
+        /** The price of the item */
+        price: number;
     }"
   `)
 })


### PR DESCRIPTION
This should put the described property on the next line after its comment.