### PR TITLE
Support generating code for a type graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ type User = {
 
 `zodToTs()` and `createTypeAlias()` return a TS AST nodes, so if you want to get the node as a string, you can use the `printNode()` utility.
 
-`zodToTs()`:
+### `zodToTs()`
 
 ```ts
 import { printNode, zodToTs } from 'zod-to-ts'
@@ -93,7 +93,7 @@ result:
 }"
 ```
 
-`createTypeAlias()`:
+### `createTypeAlias()`
 
 ```ts
 import { createTypeAlias, printNode, zodToTs } from 'zod-to-ts'
@@ -116,6 +116,42 @@ result:
     itemId: number
   }[]
 }"
+```
+
+### `zodToTsMultiple`
+
+```ts
+const address = z.object({
+  addressLine1: z.string(),
+  addressLine2: z.string()
+})
+
+const customer = z.object({
+  name: z.string(),
+  age: z.number(),
+  addresses: z.array(address),
+})
+
+const zodtoTsResult = zodToTsMultiple({
+  Customer: customer,
+  Address: address,
+})
+
+const tsSourceText = zodtoTsResult.typeAliases.map(ta => printNode(ta)).join("\n")
+```
+
+result:
+
+```ts
+type Customer = {
+    name: string;
+    age: number;
+    addresses: Address[];
+};
+type Address = {
+    addressLine1: string;
+    addressLine2: string;
+};
 ```
 
 ## Overriding Types

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"typescript": "4.9.4",
 		"vite": "4.0.3",
 		"vitest": "0.26.2",
-		"zod": "3.20.2"
+		"zod": "3.20.6"
 	},
 	"sideEffects": false,
 	"tsup": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   typescript: 4.9.4
   vite: 4.0.3
   vitest: 0.26.2
-  zod: 3.20.2
+  zod: 3.20.6
 
 devDependencies:
   '@sachinraja/eslint-config': 0.2.0_lzzuuodtsqwxnvqeq4g4likcqa
@@ -22,7 +22,7 @@ devDependencies:
   typescript: 4.9.4
   vite: 4.0.3_@types+node@18.11.18
   vitest: 0.26.2
-  zod: 3.20.2
+  zod: 3.20.6
 
 packages:
 
@@ -2449,6 +2449,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zod/3.20.2:
-    resolution: {integrity: sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==}
+  /zod/3.20.6:
+    resolution: {integrity: sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==}
     dev: true

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,3 +2,25 @@ import ts from 'typescript'
 import { printNode } from '../src'
 
 export const printNodeTest = (node: ts.Node) => printNode(node, { newLine: ts.NewLineKind.LineFeed })
+
+/**
+ * Removes indentation from inline multiline strings
+ * Useful for unit tests
+ *
+ * An alternative to Vi.JestAssertion.toMatchInlineSnapshot,
+ * because it adds annoying quotes to the snapshot text
+ */
+export const stripIndent = (indented: string): string => {
+  const lines = indented.split("\n")
+  // eslint-disable-next-line unicorn/no-array-reduce
+  const commonIndent = lines.reduce((accumulator, line) => {
+    if(/^\s*$/.test(line)) return accumulator
+    const whiteSpaceMatch = /^\s*/.exec(line)
+    const lineIndentLength = whiteSpaceMatch ? whiteSpaceMatch[0].length : 0;
+    return Math.min(accumulator, lineIndentLength)
+  }, Number.MAX_SAFE_INTEGER)
+
+  const withoutIndent = lines.map(line => line.slice(commonIndent)).join("\n")
+  // remove one leading and trailing newline, but no more than one
+  return withoutIndent.replace(/^\n/, "").replace(/\n$/,"")
+}

--- a/test/zod-to-ts-multiple.test.ts
+++ b/test/zod-to-ts-multiple.test.ts
@@ -1,0 +1,99 @@
+import {expect, it} from 'vitest'
+import {z} from 'zod'
+import {printNode, withGetType, zodToTsMultiple} from '../src'
+import {stripIndent} from "./utils";
+
+
+const address = z.object({
+  addressLine1: z.string(),
+  addressLine2: z.string()
+})
+
+const baseCustomer = z.object({
+  name: z.string(),
+  age: z.number(),
+  addresses: z.array(address),
+})
+
+type Customer = z.infer<typeof baseCustomer> & {orders: z.infer<typeof order>[]}
+
+const lazyOrder = withGetType(z.lazy(() => order), ts => ts.factory.createIdentifier('Order'))
+
+const customer: z.ZodType<Customer> = baseCustomer.extend({
+  orders: z.array(lazyOrder)
+})
+
+const productCategory = z.enum(['groceries', 'apparel', 'toys', 'other'])
+
+const discount = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('percent'),
+    percentage: z.number()
+  }),
+  z.object({
+    type: z.literal('fixed'),
+    amount: z.number()
+  })
+])
+
+const product = z.object({
+  name: z.string(),
+  sku: z.string(),
+  category: productCategory,
+  discounts: z.array(discount)
+})
+
+const order = z.object({
+  customer: customer,
+  created: z.date(),
+  products: z.array(product)
+})
+
+
+
+it('zodToTsMultiple', () => {
+
+  const zodtoTsResult = zodToTsMultiple({
+    Customer: customer,
+    Address: address,
+    ProductCategory: productCategory,
+    Discount: discount,
+    Product: product,
+    Order: order
+  })
+
+  const tsSourceText = zodtoTsResult.typeAliases.map(ta => printNode(ta)).join("\n")
+
+  expect(tsSourceText).toEqual(stripIndent(`
+    type Customer = {
+        name: string;
+        age: number;
+        addresses: Address[];
+        orders: Order[];
+    };
+    type Address = {
+        addressLine1: string;
+        addressLine2: string;
+    };
+    type ProductCategory = "groceries" | "apparel" | "toys" | "other";
+    type Discount = {
+        type: "percent";
+        percentage: number;
+    } | {
+        type: "fixed";
+        amount: number;
+    };
+    type Product = {
+        name: string;
+        sku: string;
+        category: ProductCategory;
+        discounts: Discount[];
+    };
+    type Order = {
+        customer: Customer;
+        created: Date;
+        products: Product[];
+    };
+  `))
+
+})


### PR DESCRIPTION
Most people compose their zod schemas from multiple modular type definitions.

With this feature, it's now easy to generate typescript from a zod schema that also modular.