### PR TITLE
support converting native enum to union

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ result:
 }
 ```
 
-There are two ways to solve this: provide an identifier to it or resolve all the enums inside `zodToTs()`.
+There are three ways to solve this: provide an identifier to it or resolve all the enums inside `zodToTs()`.
 
 Option 1 - providing an identifier using `withGetType()`:
 
@@ -358,7 +358,7 @@ result:
 Option 2 - resolve enums. This is the same as before, but you just need to pass an option:
 
 ```ts
-const TreeTSType = zodToTs(TreeSchema, undefined, { resolveNativeEnums: true })
+const TreeTSType = zodToTs(TreeSchema, undefined, { nativeEnums: 'resolve' })
 ```
 
 result:
@@ -384,3 +384,22 @@ result:
 Note: These are not the actual values, they are TS representation. The actual values are TS AST nodes.
 
 This option allows you to embed the enums before the schema without actually depending on an external enum type.
+
+Option 3 - convert to union. This is the same as how ZodEnum created by z.enum([...]) is handled, but need to pass an option:
+
+```ts
+const { node } = zodToTs(TreeSchema, undefined, {
+	nativeEnums: 'union',
+})
+```
+
+result:
+
+<!-- dprint-ignore -->
+```ts
+{
+  fruit: 'apple' | 'banana' | 'cantaloupe'
+}
+```
+
+Note: These are not the actual values, they are TS representation. The actual values are TS AST nodes.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,15 @@
 import ts from 'typescript'
 import { ZodTypeAny } from 'zod'
-import { GetType, GetTypeFunction, LiteralType, ZodToTsOptions, ZodToTsReturn, ZodToTsStore } from './types'
+import {
+	GetType,
+	GetTypeFunction,
+	LiteralType,
+	ResolvedZodToTsOptions,
+	resolveOptions,
+	ZodToTsOptions,
+	ZodToTsReturn,
+	ZodToTsStore,
+} from './types'
 import {
 	addJsDocComment,
 	createTypeReferenceFromString,
@@ -22,16 +31,6 @@ const callGetType = (
 	if (zod._def.getType) type = zod._def.getType(ts, identifier, options)
 	return type
 }
-
-export const resolveOptions = (raw?: ZodToTsOptions) => {
-	const resolved = {
-		nativeEnums: raw?.resolveNativeEnums ? 'resolve' : 'identifier',
-	} satisfies ZodToTsOptions
-
-	return { ...resolved, ...raw }
-}
-
-type ResolvedZodToTsOptions = ReturnType<typeof resolveOptions>
 
 export const zodToTs = (
 	zod: ZodTypeAny,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,10 +3,20 @@ import ts from 'typescript'
 export type LiteralType = string | number | boolean
 
 export type ZodToTsOptions = {
-	/** @deprecated please use nativeEnums instead */
+	/** @deprecated use `nativeEnums` instead */
 	resolveNativeEnums?: boolean
 	nativeEnums?: 'identifier' | 'resolve' | 'union'
 }
+
+export const resolveOptions = (raw?: ZodToTsOptions) => {
+	const resolved = {
+		nativeEnums: raw?.resolveNativeEnums ? 'resolve' : 'identifier',
+	} satisfies ZodToTsOptions
+
+	return { ...resolved, ...raw }
+}
+
+export type ResolvedZodToTsOptions = ReturnType<typeof resolveOptions>
 
 export type ZodToTsStore = {
 	nativeEnums: ts.EnumDeclaration[]
@@ -20,7 +30,7 @@ export type ZodToTsReturn = {
 export type GetTypeFunction = (
 	typescript: typeof ts,
 	identifier: string,
-	options: ZodToTsOptions,
+	options: ResolvedZodToTsOptions,
 ) => ts.Identifier | ts.TypeNode
 
 export type GetType = { _def: { getType?: GetTypeFunction } }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,8 +8,6 @@ export type ZodToTsOptions = {
 	nativeEnums?: 'identifier' | 'resolve' | 'union'
 }
 
-export type RequiredZodToTsOptions = Required<ZodToTsOptions>
-
 export type ZodToTsStore = {
 	nativeEnums: ts.EnumDeclaration[]
 }
@@ -22,7 +20,7 @@ export type ZodToTsReturn = {
 export type GetTypeFunction = (
 	typescript: typeof ts,
 	identifier: string,
-	options: RequiredZodToTsOptions,
+	options: ZodToTsOptions,
 ) => ts.Identifier | ts.TypeNode
 
 export type GetType = { _def: { getType?: GetTypeFunction } }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,9 @@ import ts from 'typescript'
 export type LiteralType = string | number | boolean
 
 export type ZodToTsOptions = {
+	/** @deprecated please use nativeEnums instead */
 	resolveNativeEnums?: boolean
+	nativeEnums?: 'identifier' | 'resolve' | 'union'
 }
 
 export type RequiredZodToTsOptions = Required<ZodToTsOptions>

--- a/test/enum.test.ts
+++ b/test/enum.test.ts
@@ -55,7 +55,7 @@ describe('Fruit enum', () => {
 			(ts) => ts.factory.createIdentifier('Fruit'),
 		)
 
-		const { store } = zodToTs(schema, undefined, { resolveNativeEnums: true })
+		const { store } = zodToTs(schema, undefined, { nativeEnums: 'resolve' })
 
 		expect(printNodeTest(store.nativeEnums[0])).toMatchInlineSnapshot(`
 			"enum Fruit {
@@ -79,7 +79,7 @@ it('handles string literal properties', () => {
 		(ts) => ts.factory.createIdentifier('StringLiteral'),
 	)
 
-	const { store } = zodToTs(schema, undefined, { resolveNativeEnums: true })
+	const { store } = zodToTs(schema, undefined, { nativeEnums: 'resolve' })
 
 	expect(printNodeTest(store.nativeEnums[0])).toMatchInlineSnapshot(`
 		"enum StringLiteral {
@@ -91,4 +91,28 @@ it('handles string literal properties', () => {
 		    \\"\\\\\\\\\\\\\\"Escaped\\\\\\\\\\\\\\"\\" = 2
 		}"
 	`)
+})
+
+describe('convertNativeEnumToUnion option', () => {
+	it('handles number enum', () => {
+		enum Color {
+			Red,
+			Green,
+			Blue,
+		}
+		const schema = z.nativeEnum(Color)
+		const { node } = zodToTs(schema, undefined, { nativeEnums: 'union' })
+		expect(printNodeTest(node)).toMatchInlineSnapshot(`"\\"Red\\" | \\"Green\\" | \\"Blue\\" | 0 | 1 | 2"`)
+	})
+
+	it('handles string enum', () => {
+		enum Fruit {
+			Apple = 'apple',
+			Banana = 'banana',
+			Cantaloupe = 'cantaloupe',
+		}
+		const schema = z.nativeEnum(Fruit)
+		const { node } = zodToTs(schema, undefined, { nativeEnums: 'union' })
+		expect(printNodeTest(node)).toMatchInlineSnapshot(`"\\"apple\\" | \\"banana\\" | \\"cantaloupe\\""`)
+	})
 })

--- a/test/example.ts
+++ b/test/example.ts
@@ -22,7 +22,7 @@ const pickedSchema = example2.partial()
 const nativeEnum = withGetType(z.nativeEnum(Fruits), (ts, _, options) => {
 	const identifier = ts.factory.createIdentifier('Fruits')
 
-	if (options.resolveNativeEnums) return identifier
+	if (options.nativeEnums === 'resolve') return identifier
 
 	return ts.factory.createTypeReferenceNode(
 		identifier,
@@ -103,7 +103,7 @@ type A = z.infer<typeof example>['ee']
 
 type B = z.infer<typeof pickedSchema>
 
-const { node, store } = zodToTs(example, 'Example', { resolveNativeEnums: true })
+const { node, store } = zodToTs(example, 'Example', { nativeEnums: 'resolve' })
 
 console.log(printNode(node))
 

--- a/test/example2.ts
+++ b/test/example2.ts
@@ -12,7 +12,7 @@ const schema = z.object({
 	key: Enum.describe('Comment for key'),
 })
 
-const { node } = zodToTs(schema, undefined, { resolveNativeEnums: true })
+const { node } = zodToTs(schema, undefined, { nativeEnums: 'resolve' })
 console.log(printNode(node))
 // {
 //     /** Comment for key */


### PR DESCRIPTION
This PR adds a new option `convertNativeEnumToUnion`. When it's `true`, this option supersedes the `resolveNativeEnums` option and will turn native enums to a union type similar to how the `ZodEnum` is converted. This can be the desired behaviour in some cases as enum is in some way a union of a list of predefined literals.