### PR TITLE
Fix optional error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ const zodToTsNode = (
 				const type = zodToTsNode(nextZodNode, ...otherArguments)
 
 				const { typeName: nextZodNodeTypeName } = nextZodNode._def
-				const isOptional = nextZodNodeTypeName === 'ZodOptional' || nextZodNode.isOptional()
+				const isOptional = nextZodNodeTypeName === 'ZodOptional';
 
 				const propertySignature = f.createPropertySignature(
 					undefined,


### PR DESCRIPTION
I found an error where when using the default() method, a field that should not be optional becomes optional. z.isOptional() seems to indicate whether the input value is optional, not whether the output type is optional.

![Capture](https://github.com/sachinraja/zod-to-ts/assets/30170252/00e905dd-d496-4c0b-9d05-7abb46dac87a)
