### PR TITLE
fix: add types export for node16 module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"./package.json": "./package.json",
 		".": {
 			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.cjs"
 		}
 	},


### PR DESCRIPTION
Consumers using `node16` or `nodenext` module resolution cannot access the types shipped with this package without a `types` entry in the conditional exports.  See https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution for details