### PR TITLE
feat: add z.catch() resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,8 @@ const zodToTsNode = (
 				const type = zodToTsNode(nextZodNode, ...otherArguments)
 
 				const { typeName: nextZodNodeTypeName } = nextZodNode._def
-				const isOptional = nextZodNodeTypeName === 'ZodOptional' || nextZodNode.isOptional() && nextZodNodeTypeName !== 'ZodCatch'
+				const isOptional = nextZodNodeTypeName === 'ZodOptional'
+					|| nextZodNode.isOptional() && nextZodNodeTypeName !== 'ZodCatch'
 
 				const propertySignature = f.createPropertySignature(
 					undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ const zodToTsNode = (
 				const type = zodToTsNode(nextZodNode, ...otherArguments)
 
 				const { typeName: nextZodNodeTypeName } = nextZodNode._def
-				const isOptional = nextZodNodeTypeName === 'ZodOptional' || nextZodNode.isOptional()
+				const isOptional = nextZodNodeTypeName === 'ZodOptional' || nextZodNode.isOptional() && nextZodNodeTypeName !== 'ZodCatch'
 
 				const propertySignature = f.createPropertySignature(
 					undefined,
@@ -374,6 +374,12 @@ const zodToTsNode = (
 			// @ts-expect-error needed to set children
 			type.types = filteredNodes
 
+			return type
+		}
+
+		case 'ZodCatch': {
+			// z.enum(['a', 'b', 'c']).catch('a') -> 'a' | 'b' | 'c'
+			const type = zodToTsNode(zod._def.innerType, ...otherArguments) as ts.TypeNode
 			return type
 		}
 	}

--- a/test/catch.test.ts
+++ b/test/catch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { zodToTs } from '../src'
+import { printNodeTest } from './utils'
+
+const ListSchema = z.object({
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+	items: z.enum(['a', 'b', 'c']).catch("a") 
+}).array()
+
+describe('z.catch()', () => {
+	const { node } = zodToTs(ListSchema, 'List')
+
+	it('outputs correct typescript', () => {
+		expect(printNodeTest(node)).toMatchInlineSnapshot(`
+			"{
+			    items: \\"a\\" | \\"b\\" | \\"c\\";
+			}[]"
+		`)
+	})
+})

--- a/test/catch.test.ts
+++ b/test/catch.test.ts
@@ -4,8 +4,8 @@ import { zodToTs } from '../src'
 import { printNodeTest } from './utils'
 
 const ListSchema = z.object({
-  // eslint-disable-next-line unicorn/prefer-top-level-await
-	items: z.enum(['a', 'b', 'c']).catch("a") 
+	// eslint-disable-next-line unicorn/prefer-top-level-await
+	items: z.enum(['a', 'b', 'c']).catch('a'),
 }).array()
 
 describe('z.catch()', () => {


### PR DESCRIPTION
Fixes #60.

Adds support for `z.catch` so that the type is not set to `any`.

```ts
z.object({
    items: z.enum(['a', 'b', 'c']).catch('a'),
}).array()
```

Resolves to:

```ts
{
   items: "a" | "b" | "c";
}[]
```
