### PR TITLE
Omit the undefined type when the object property is marked as optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,11 +134,16 @@ const zodToTsNode = (
 			const properties = Object.entries(zod._def.shape())
 
 			const members: ts.TypeElement[] = properties.map(([key, value]) => {
-				const nextZodNode = value as ZodTypeAny
-				const type = zodToTsNode(nextZodNode, ...otherArguments)
+				let nextZodNode = value as ZodTypeAny
 
 				const { typeName: nextZodNodeTypeName } = nextZodNode._def
 				const isOptional = nextZodNodeTypeName === 'ZodOptional' || nextZodNode.isOptional()
+
+				if (nextZodNodeTypeName === 'ZodOptional') {
+					nextZodNode = nextZodNode.unwrap()
+				}
+
+				const type = zodToTsNode(nextZodNode, ...otherArguments)
 
 				const propertySignature = f.createPropertySignature(
 					undefined,

--- a/test/modifiers.test.ts
+++ b/test/modifiers.test.ts
@@ -31,7 +31,7 @@ describe('z.optional()', () => {
 
 		expect(printNodeTest(node)).toMatchInlineSnapshot(`
 			"{
-			    optional?: string | undefined;
+			    optional?: string;
 			    required: string;
 			    transform?: number | undefined;
 			    or?: (number | undefined) | string;
@@ -39,10 +39,10 @@ describe('z.optional()', () => {
 			        string | undefined,
 			        number,
 			        {
-			            optional?: string | undefined;
+			            optional?: string;
 			            required: string;
 			        }
-			    ] | undefined;
+			    ];
 			}"
 		`)
 	})


### PR DESCRIPTION
I like this because it makes the types a bit more concise. Not sure what other people's opinion is?