### PR TITLE
chore: add license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "zod-to-ts",
 	"version": "1.2.0",
 	"type": "module",
+	"license": "MIT",
 	"description": "generate TypeScript types from your Zod schema",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Add `license` field to package.json as per best practice guidelines and code scanning e.g. Blackduck can detect the license type properly.