### PR TITLE
fix: partialRecord not outputting a partial type and record with enum/literal keys outputting an invalid type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -242,27 +242,57 @@ function zodToTsNode(
 		}
 
 		case 'record': {
-			// z.record(z.number()) -> { [x: string]: number }
+			// z.record(z.string(), z.number()) -> { [x: string]: number }
 			const keyType = zodToTsNode(def.keyType, options)
 			const valueType = zodToTsNode(def.valueType, options)
+			// where we need { [x in K]: V } instead of { [x: K]: V }
+			const needsMappedType =
+				def.keyType._zod.def.type === 'enum' ||
+				def.keyType._zod.def.type === 'literal'
+			const isPartial = def.keyType._zod.values === undefined
 
-			const node = f.createTypeLiteralNode([
-				f.createIndexSignature(
+			if (needsMappedType) {
+				return f.createMappedTypeNode(
 					undefined,
-					[
-						f.createParameterDeclaration(
-							undefined,
-							undefined,
-							f.createIdentifier('key'),
-							undefined,
-							keyType,
-						),
-					],
+					f.createTypeParameterDeclaration(
+						undefined,
+						f.createIdentifier('key'),
+						keyType,
+					),
+					undefined,
+					isPartial ? f.createToken(ts.SyntaxKind.QuestionToken) : undefined,
 					valueType,
-				),
-			])
-
-			return node
+					undefined,
+				)
+			} else {
+				return f.createTypeLiteralNode([
+					f.createIndexSignature(
+						undefined,
+						[
+							f.createParameterDeclaration(
+								undefined,
+								undefined,
+								f.createIdentifier('key'),
+								undefined,
+								keyType,
+							),
+						],
+						// this results in a different type than zod for a record of string keys:
+						// we return { [key: string]: T | undefined } and zod returns { [key: string]: T }.
+						// but those are only semantically different if you don't use noUncheckedIndexedAccess.
+						//
+						// zod implements partialRecord() by setting values to undefined on the key type and then
+						// calling record(), so i don't think it is possible to tell whether you called
+						// partialRecord() or record() for key types that would already have values set to undefined.
+						isPartial
+							? f.createUnionTypeNode([
+									valueType,
+									f.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
+								])
+							: valueType,
+					),
+				])
+			}
 		}
 
 		case 'map': {

--- a/test/lazy.test.ts
+++ b/test/lazy.test.ts
@@ -43,7 +43,7 @@ describe('z.json()', () => {
 			  {
 			    "identifier": "Auxiliary_0",
 			    "node": "type Auxiliary_0 = string | number | boolean | null | Auxiliary_0[] | {
-			    [key: string]: Auxiliary_0;
+			    [key: string]: Auxiliary_0 | undefined;
 			};",
 			  },
 			]

--- a/test/record.test.ts
+++ b/test/record.test.ts
@@ -1,0 +1,52 @@
+import { expect, it } from 'vitest'
+import { z } from 'zod'
+import { createAuxiliaryTypeStore, zodToTs } from '../src'
+import { printNodeTest } from './utils'
+
+it('prints correct typescript for record with string key', () => {
+	const schema = z.record(z.string(), z.number())
+	const auxiliaryTypeStore = createAuxiliaryTypeStore()
+	const { node } = zodToTs(schema, { auxiliaryTypeStore })
+	expect(printNodeTest(node)).toMatchInlineSnapshot(`
+    "{
+        [key: string]: number | undefined;
+    }"
+  `)
+	expect(auxiliaryTypeStore.definitions.size).toBe(0)
+})
+
+it('prints correct typescript for partial record with string key', () => {
+	const schema = z.partialRecord(z.string(), z.number())
+	const auxiliaryTypeStore = createAuxiliaryTypeStore()
+	const { node } = zodToTs(schema, { auxiliaryTypeStore })
+	expect(printNodeTest(node)).toMatchInlineSnapshot(`
+    "{
+        [key: string]: number | undefined;
+    }"
+  `)
+	expect(auxiliaryTypeStore.definitions.size).toBe(0)
+})
+
+it('prints correct typescript for record with enum key', () => {
+	const schema = z.record(z.enum(['foo', 'bar']), z.number())
+	const auxiliaryTypeStore = createAuxiliaryTypeStore()
+	const { node } = zodToTs(schema, { auxiliaryTypeStore })
+	expect(printNodeTest(node)).toMatchInlineSnapshot(`
+    "{
+        [key in "foo" | "bar"]: number;
+    }"
+  `)
+	expect(auxiliaryTypeStore.definitions.size).toBe(0)
+})
+
+it('prints correct typescript for partial record with enum key', () => {
+	const schema = z.partialRecord(z.enum(['foo', 'bar']), z.number())
+	const auxiliaryTypeStore = createAuxiliaryTypeStore()
+	const { node } = zodToTs(schema, { auxiliaryTypeStore })
+	expect(printNodeTest(node)).toMatchInlineSnapshot(`
+    "{
+        [key in "foo" | "bar"]?: number;
+    }"
+  `)
+	expect(auxiliaryTypeStore.definitions.size).toBe(0)
+})


### PR DESCRIPTION
- fix `partialRecord` outputting the same type as `record` (not actually partial)
- fix `record` or `partialRecord` with `enum` or `literal` keys printing invalid typescript

There is a breaking change here that the type for `z.record(z.string(), z.number())` is now `{ [key: string]: number | undefined }` instead of `{ [key: string]: number }`. These are semantically the same type if you use `noUncheckedIndexedAccess`, but not otherwise. I don't think it's possible to avoid this because when the key type is a string, it doesn't seem possible to tell at runtime whether it is a partial record (see my comment), so we have to generate the same type for partial and non-partial records, and doing this thing is better than outputting a non-partial type for partial records (which would be unsafe).