### PR TITLE
feat: overrideFunction option to implement overrides without a map

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,13 @@ import { handleUnrepresentable, literalValueToLiteralType } from './utils'
 
 function callTypeOverride(schema: z4.$ZodType, options: ZodToTsOptions) {
 	const getTypeOverride = options.overrides?.get(schema)
-	if (!getTypeOverride) return
-
-	return getTypeOverride(ts, options)
+	if (getTypeOverride) {
+		return getTypeOverride(ts, options)
+	} else if (options.overrideFunction) {
+		return options.overrideFunction(schema, ts, options)
+	} else {
+		return undefined
+	}
 }
 
 function withAuxiliaryType(
@@ -471,5 +475,11 @@ function zodToTsNode(
 }
 
 export { createTypeAlias, printNode } from './ast-helpers'
-export type { TypeOverrideMap, ZodToTsOptions } from './types'
+export type {
+	TypeOverrideMap,
+	ZodToTsOptions,
+	AuxiliaryTypeStore,
+	TypeOverrideFunction,
+	OptionalTypeOverrideFunction,
+} from './types'
 export { createAuxiliaryTypeStore } from './utils'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,41 @@
 import type ts from 'typescript'
 import * as z4 from 'zod/v4/core'
 
+/** A function which overrides the default Zod to TypeScript mapping.
+ * @param typescript TypeScript compiler interface for creating AST nodes
+ * @param options The options that were passed to `zodToTs`
+ * @returns the TypeScript AST node for this Zod type
+ */
 export type TypeOverrideFunction = (
 	typescript: typeof ts,
 	options: ZodToTsOptions,
 ) => ts.TypeNode
+
+/** A function which may optionally override the default Zod to TypeScript mapping.
+ * @param schema Zod schema to potentially override
+ * @param typescript TypeScript compiler interface for creating AST nodes
+ * @param options The options that were passed to `zodToTs`
+ * @returns the TypeScript AST node for this Zod type, or `undefined` if this Zod type should not be overridden
+ */
+export type OptionalTypeOverrideFunction = (
+	schema: z4.$ZodType,
+	typescript: typeof ts,
+	options: ZodToTsOptions,
+) => ts.TypeNode | undefined
 
 export type TypeOverrideMap = Map<z4.$ZodType, TypeOverrideFunction>
 
 interface OptionalZodToTsOptions {
 	/**
 	 * A registry of Zod schemas to override the type generation for.
+	 * Takes precedence over `overrideFunction`.
 	 */
 	overrides: TypeOverrideMap
+	/**
+	 * A function to optionally override Zod types not matched in `overrides`.
+	 * Types that appear in `overrides` will be mapped there instead of passed to this function.
+	 */
+	overrideFunction: OptionalTypeOverrideFunction
 }
 
 interface WithDefaultZodToTsOptions {
@@ -65,6 +88,7 @@ export function resolveOptions(
 		unrepresentable: options.unrepresentable ?? 'throw',
 		io: options.io ?? 'output',
 		overrides: options.overrides,
+		overrideFunction: options.overrideFunction,
 		metadataRegistry: options.metadataRegistry ?? z4.globalRegistry,
 		auxiliaryTypeStore: options.auxiliaryTypeStore,
 	}

--- a/test/override.test.ts
+++ b/test/override.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+import { createAuxiliaryTypeStore, TypeOverrideMap, zodToTs } from '../src'
+import { printNodeTest } from './utils'
+
+describe('overrides option', () => {
+	it('overrides default conversion', () => {
+		const overrideMe = z.string()
+		const schema = z.object({ override: overrideMe, dontOverride: z.string() })
+		const auxiliaryTypeStore = createAuxiliaryTypeStore()
+		const overrides: TypeOverrideMap = new Map([
+			[overrideMe, (ts) => ts.factory.createTypeReferenceNode('Overridden')],
+		])
+
+		const { node } = zodToTs(schema, { auxiliaryTypeStore, overrides })
+		expect(printNodeTest(node)).toMatchInlineSnapshot(`
+			"{
+			    override: Overridden;
+			    dontOverride: string;
+			}"
+		`)
+	})
+
+	it('overrides overrideFunction', () => {
+		const overrideMe = z.string()
+		const schema = z.object({ override: overrideMe, dontOverride: z.string() })
+		const auxiliaryTypeStore = createAuxiliaryTypeStore()
+		const overrides: TypeOverrideMap = new Map([
+			[
+				overrideMe,
+				(ts) => ts.factory.createTypeReferenceNode('OverriddenByMap'),
+			],
+		])
+
+		const { node } = zodToTs(schema, {
+			auxiliaryTypeStore,
+			overrides,
+			overrideFunction: (schema, ts) => {
+				if (schema === overrideMe) {
+					return ts.factory.createTypeReferenceNode('OverriddenByFunction')
+				} else {
+					return undefined
+				}
+			},
+		})
+		expect(printNodeTest(node)).toMatchInlineSnapshot(`
+			"{
+			    override: OverriddenByMap;
+			    dontOverride: string;
+			}"
+		`)
+	})
+})
+
+it('overrideFunction option', () => {
+	const overrideMe = z.string()
+	const schema = z.object({ override: overrideMe, dontOverride: z.string() })
+	const auxiliaryTypeStore = createAuxiliaryTypeStore()
+	const { node } = zodToTs(schema, {
+		auxiliaryTypeStore,
+		overrideFunction: (schema, ts) => {
+			if (schema === overrideMe) {
+				return ts.factory.createTypeReferenceNode('Overridden')
+			} else {
+				return undefined
+			}
+		},
+	})
+	expect(printNodeTest(node)).toMatchInlineSnapshot(`
+		"{
+		    override: Overridden;
+		    dontOverride: string;
+		}"
+	`)
+})


### PR DESCRIPTION
Fixes #103

This allows you to implement more fine-grained override logic than you can achieve with a map.

I also added more type re-exports in `index.ts` because I found it helpful to have access to these for writing type annotations in my own code.