### PR TITLE
Added the ability to extract description from wrapper types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,25 @@ function callTypeOverride(schema: z4.$ZodType, options: ZodToTsOptions) {
 	return getTypeOverride(ts, options)
 }
 
+// This only applies to wrapper types
+function hasInnerType(def: z4.$ZodTypeDef): def is z4.$ZodTypeDef & { innerType: z4.$ZodType } {
+	return 'innerType' in def
+}
+
+function getDescriptionFromSchema(
+	schema: z4.$ZodType,
+	options: ResolvedZodToTsOptions,
+): string | undefined {
+	const directDescription = options.metadataRegistry?.get(schema)?.description
+	if (directDescription) return directDescription
+
+	if (hasInnerType(schema._zod.def)) {
+		return options.metadataRegistry?.get(schema._zod.def.innerType)?.description
+	}
+
+	return undefined
+}
+
 function withAuxiliaryType(
 	schema: z4.$ZodType,
 	getInner: () => ts.TypeNode,
@@ -162,8 +181,7 @@ function zodToTsNode(
 								type,
 							)
 
-							const description =
-								options.metadataRegistry?.get(memberZodSchema)?.description
+							const description = getDescriptionFromSchema(memberZodSchema, options)
 							if (description) {
 								addJsDocComment(propertySignature, description)
 							}

--- a/test/describe.test.ts
+++ b/test/describe.test.ts
@@ -22,3 +22,23 @@ describe('z.describe()', () => {
 		`)
 	})
 })
+
+describe('z.describe().optional()', () => {
+	it('supports describing optional schema', () => {
+		const keySchema = z.string()
+
+		const schema = z.object({
+			key: keySchema.describe('Comment for key').optional(),
+		})
+
+		const auxiliaryTypeStore = createAuxiliaryTypeStore()
+		const { node } = zodToTs(schema, { auxiliaryTypeStore })
+
+		expect(printNodeTest(node)).toMatchInlineSnapshot(`
+			"{
+			    /** Comment for key */
+			    key?: string | undefined;
+			}"
+		`)
+	})
+})


### PR DESCRIPTION
I noticed that when defining a description like this:

```typescript
z.number().description('test description').optional()
```
The description is not transformed into a comment. However, this works

```typescript
z.number().optional().description('test description')
```

I have added a fix for all wrapper types and also added a test case to verify.

Issue was referenced here: https://github.com/sachinraja/zod-to-ts/issues/98